### PR TITLE
Handle detour road events without throwing an exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ The library provides the following functionality:
 - Create a WZDx [WorkZoneFeed](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/WorkZoneFeed.md) or [DeviceFeed](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/DeviceFeed.md) GeoJSON string by serializing WZDx C# objects modeled in this library.
 - Deserialize a WZDx Work Zone Feed or Device Feed GeoJSON string into C# objects modeled in this library.
 
-WZDx v4.0 and v4.1 are supported. The [WzdxSerializer](./src/IBI.WZDx/Serialization/WzdxSerializer.cs) defaults to outputting v4.1 (latest WZDx).
+### WZDx Version Support
+
+WZDx versions 4.0 and 4.1 are supported; the [WzdxSerializer](./src/IBI.WZDx/Serialization/WzdxSerializer.cs) defaults to outputting v4.1 (latest WZDx).
+
+[Detour road events](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/DetourRoadEvent.md) are not supported. When provided with a Work Zone Feed that includes detour road events, the WzdxSerializer.DeserializeFeed method will deserialize the detour events into a [RoadEventFeature](./src/IBI.WZDx/Models/RoadEvents/RoadEventFeature.cs) with `Properties` as `null`.
 
 ## Usage
 

--- a/src/IBI.WZDx/Serialization/RoadEventConverter.cs
+++ b/src/IBI.WZDx/Serialization/RoadEventConverter.cs
@@ -46,6 +46,7 @@ internal class RoadEventConverter : JsonConverter<IRoadEvent>
         return eventType switch
         {
             "work-zone" => deserializeAsType(typeof(WorkZoneRoadEvent)),
+            "detour" => null,
             _ => throw new JsonException($"Unsupported event type '{eventType}'.")
         };
     }

--- a/tests/IBI.WZDx.UnitTests/WzdxSerializerTests.cs
+++ b/tests/IBI.WZDx.UnitTests/WzdxSerializerTests.cs
@@ -627,11 +627,29 @@ public class WzdxSerializerTests
         [Fact]
         public void DeserializeFeed_JsonValid_DoesNotThrowException()
         {
-            var action = () => WzdxSerializer.DeserializeFeed<WorkZoneFeed>(_testValidWorkZoneFeed);
+            var action = () => WzdxSerializer.DeserializeFeed<WorkZoneFeed>(_testValidWorkZoneFeedWithoutDetours);
 
             var exception = Record.Exception(action);
 
             Assert.Null(exception);
+        }
+
+        [Fact]
+        public void DeserializeFeed_IncludesDetours_DoesNotThrowException()
+        {
+            var action = () => WzdxSerializer.DeserializeFeed<WorkZoneFeed>(_testValidWorkZoneFeedWithDetours);
+
+            var exception = Record.Exception(action);
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void DeserializeFeed_IncludesDetours_DetourFeaturePropertiesIsNull()
+        {
+            WorkZoneFeed actualFeedObject = WzdxSerializer.DeserializeFeed<WorkZoneFeed>(_testValidWorkZoneFeedWithDetours);
+
+            Assert.Null(actualFeedObject.Features.First().Properties);
         }
 
         [Theory]
@@ -984,7 +1002,7 @@ public class WzdxSerializerTests
                 }
             };
 
-        private static string _testValidWorkZoneFeed = @"
+        private static string _testValidWorkZoneFeedWithoutDetours = @"
             {
                 ""feed_info"": {
                     ""update_date"": ""2020-06-18T15:00:00Z"",
@@ -1791,6 +1809,73 @@ public class WzdxSerializerTests
                                 -93.742189315999951,
                                 41.592481500000076
                             ]
+                            ]
+                        }
+                    }
+                ]
+            }";
+
+        private static string _testValidWorkZoneFeedWithDetours = @"
+            {
+                ""feed_info"": {
+                    ""update_date"": ""2020-06-18T15:00:00Z"",
+                    ""publisher"": ""TestDOT"",
+                    ""version"": ""4.1"",
+                    ""license"": ""https://creativecommons.org/publicdomain/zero/1.0/"",
+                    ""data_sources"": [
+                        {
+                            ""data_source_id"": ""1"",
+                            ""organization_name"": ""Test City 1""
+                        }
+                    ]
+                },
+                ""type"": ""FeatureCollection"",
+                ""features"": [
+                    {
+                        ""id"": ""71234"",
+                        ""type"": ""Feature"",
+                        ""properties"": {
+                            ""core_details"": {
+                                ""data_source_id"": ""1"",
+                                ""event_type"": ""detour"",
+                                ""road_names"": [
+                                    ""I-80""
+                                ],
+                                ""direction"": ""northbound"",
+                                ""description"": ""Test detour.""
+                            },
+                            ""is_start_date_verified"": false,
+                            ""is_end_date_verified"": false,
+                            ""start_date"": ""2010-01-01T01:00:00Z"",
+                            ""end_date"": ""2010-01-02T01:00:00Z""
+                        },
+                        ""geometry"": {
+                            ""type"": ""LineString"",
+                            ""coordinates"": [
+                                [
+                                    -93.776684050999961,
+                                    41.617961698000045
+                                ],
+                                [
+                                    -93.776682957,
+                                    41.618244962000063
+                                ],
+                                [
+                                    -93.776677372999984,
+                                    41.619603362000078
+                                ],
+                                [
+                                    -93.776674365999952,
+                                    41.620322783000063
+                                ],
+                                [
+                                    -93.776671741999962,
+                                    41.620950321000066
+                                ],
+                                [
+                                    -93.776688974999956,
+                                    41.622297226000057
+                                ]
                             ]
                         }
                     }


### PR DESCRIPTION
This PR updates the RoadEventConverter to return `null` when serializing a road event with type `"detour"`, rather than throwing an exception.

It updates the documentation and unit tests to clarify the new behavior.

This feature enables the library to be used to process Work Zone Feeds that have detours in them.