### PR TITLE
Support WZDx v4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The library provides the following functionality:
 
 ### WZDx Version Support
 
-WZDx versions 4.0 and 4.1 are supported; the [WzdxSerializer](./src/IBI.WZDx/Serialization/WzdxSerializer.cs) defaults to outputting v4.1 (latest WZDx).
+WZDx versions 4.0, 4.1 & 4.2 are supported; the [WzdxSerializer](./src/IBI.WZDx/Serialization/WzdxSerializer.cs) defaults to outputting v4.2 (latest WZDx).
 
 [Detour road events](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/DetourRoadEvent.md) are not supported. When provided with a Work Zone Feed that includes detour road events, the WzdxSerializer.DeserializeFeed method will deserialize the detour events into a [RoadEventFeature](./src/IBI.WZDx/Models/RoadEvents/RoadEventFeature.cs) with `Properties` as `null`.
 

--- a/src/IBI.WZDx/IBI.WZDx.csproj
+++ b/src/IBI.WZDx/IBI.WZDx.csproj
@@ -7,7 +7,7 @@
     <Description>Models and utitlies for producing and consuming Work Zone Data Exchange (WZDx) data feeds.</Description>
     <PackageTags>WZDx;Work Zone Data Exchange;Work Zone Feed;Road Event;Device Feed;Field Device;GeoJSON</PackageTags>
     <Authors>IBI Group</Authors>
-    <VersionPrefix>4.1.0</VersionPrefix>
+    <VersionPrefix>4.2.0</VersionPrefix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryType>git</RepositoryType>

--- a/src/IBI.WZDx/Models/FieldDevices/FieldDeviceCoreDetails.cs
+++ b/src/IBI.WZDx/Models/FieldDevices/FieldDeviceCoreDetails.cs
@@ -72,6 +72,9 @@ namespace IBI.WZDx.Models.FieldDevices;
 /// <param name="FirmwareVersion">
 ///  The version of firmware the device is using to operate.
 /// </param>
+/// <param name="VelocityKph">
+/// The velocity of the device in kilometers per hour.
+/// </param>
 public record FieldDeviceCoreDetails(
     FieldDeviceType DeviceType,
     string DataSourceId,
@@ -89,7 +92,8 @@ public record FieldDeviceCoreDetails(
     string? Make = null,
     string? Model = null,
     string? SerialNumber = null,
-    string? FirmwareVersion = null
+    string? FirmwareVersion = null,
+    double? VelocityKph = null
     )
 {
     /// <inheritdoc/>
@@ -112,7 +116,8 @@ public record FieldDeviceCoreDetails(
             && Make == other.Make
             && Model == other.Model
             && SerialNumber == other.SerialNumber
-            && FirmwareVersion == other.FirmwareVersion;
+            && FirmwareVersion == other.FirmwareVersion
+            && VelocityKph == other.VelocityKph;
     }
 
     /// <inheritdoc/>
@@ -184,6 +189,11 @@ public record FieldDeviceCoreDetails(
             {
                 hash.Add(roadEventId);
             }
+        }
+
+        if (VelocityKph != null)
+        {
+            hash.Add(VelocityKph);
         }
 
         return hash.ToHashCode();

--- a/src/IBI.WZDx/Models/FieldDevices/FlashingBeacon.cs
+++ b/src/IBI.WZDx/Models/FieldDevices/FlashingBeacon.cs
@@ -1,8 +1,9 @@
 namespace IBI.WZDx.Models.FieldDevices;
 
 /// <summary>
-/// Describes a flashing beacon light of any form (e.g. trailer-mounted, vehicle), used to indicate
-/// something and capture driver attention.
+/// The FlashingBeacon object describes a flashing warning beacon used to supplement a temporary 
+/// traffic control device. A flashing warning beacon is mounted on a sign or channelizing device 
+/// and used to indicate a warning condition and capture driver attention.
 /// </summary>
 /// <param name="CoreDetails">
 /// The core details of the flashing beacon device.

--- a/src/IBI.WZDx/Models/FieldDevices/FlashingBeacon.cs
+++ b/src/IBI.WZDx/Models/FieldDevices/FlashingBeacon.cs
@@ -1,7 +1,7 @@
 namespace IBI.WZDx.Models.FieldDevices;
 
 /// <summary>
-/// The FlashingBeacon object describes a flashing warning beacon used to supplement a temporary 
+/// Describes a flashing warning beacon used to supplement a temporary 
 /// traffic control device. A flashing warning beacon is mounted on a sign or channelizing device 
 /// and used to indicate a warning condition and capture driver attention.
 /// </summary>

--- a/src/IBI.WZDx/Models/FieldDevices/MarkedLocationType.cs
+++ b/src/IBI.WZDx/Models/FieldDevices/MarkedLocationType.cs
@@ -69,6 +69,11 @@ public enum MarkedLocationType
     RoadClosure,
 
     /// <summary>
+    /// A work truck with lights flashing, actively engaged in construction or maintenance activity on the roadway.
+    /// </summary>
+    WorkTruckWithLightsFlashing,
+
+    /// <summary>
     /// A temporary traffic signal.
     /// </summary>
     [Obsolete("Use TrafficSignal field device object instead.")]

--- a/src/IBI.WZDx/Models/RoadDirection.cs
+++ b/src/IBI.WZDx/Models/RoadDirection.cs
@@ -33,6 +33,16 @@ public enum RoadDirection
     Westbound,
 
     /// <summary>
+    /// The road direction is on the inner loop of a ring road or beltway.
+    /// </summary>
+    InnerLoop,
+
+    /// <summary>
+    /// The road direction is on the outer loop of a ring road or beltway.
+    /// </summary>
+    OuterLoop,
+
+    /// <summary>
     /// The road does not have a signed direction.
     /// </summary>
     /// <remarks>

--- a/src/IBI.WZDx/Models/RoadEvents/CdsCurbZonesReference.cs
+++ b/src/IBI.WZDx/Models/RoadEvents/CdsCurbZonesReference.cs
@@ -6,14 +6,16 @@ namespace IBI.WZDx.Models.RoadEvents;
 
 /// <summary>
 /// Describes specific curb zones that are impacted by a work zone via an external reference to the
-/// curb data specification's.
+/// curb data specification's 
+/// <see href="https://github.com/openmobilityfoundation/curb-data-specification/tree/main/curbs#curb-zone">
+/// Curb API
+/// </see>.
 /// </summary>
 /// <param name="CdsCurbZoneIds">A list of 
 /// <see href="https://github.com/openmobilityfoundation/curb-data-specification/tree/main/curbs#curb-zone">
 /// CDS Curb Zone
 /// </see> 
-/// <c>id</c>s.
-/// </param>
+/// <c>id</c>s.</param>
 /// <param name="CdsCurbsApiUrl">An identifier for the source of the requested CDS Curbs API.</param>
 public record CdsCurbZonesReference(
     IEnumerable<string> CdsCurbZoneIds,

--- a/src/IBI.WZDx/Models/RoadEvents/CdsCurbZonesReference.cs
+++ b/src/IBI.WZDx/Models/RoadEvents/CdsCurbZonesReference.cs
@@ -8,7 +8,12 @@ namespace IBI.WZDx.Models.RoadEvents;
 /// Describes specific curb zones that are impacted by a work zone via an external reference to the
 /// curb data specification's.
 /// </summary>
-/// <param name="CdsCurbZoneIds">A list of CDS Curb Zone Ids</param>
+/// <param name="CdsCurbZoneIds">A list of 
+/// <see href="https://github.com/openmobilityfoundation/curb-data-specification/tree/main/curbs#curb-zone">
+/// CDS Curb Zone
+/// </see> 
+/// <c>id</c>s.
+/// </param>
 /// <param name="CdsCurbsApiUrl">An identifier for the source of the requested CDS Curbs API.</param>
 public record CdsCurbZonesReference(
     IEnumerable<string> CdsCurbZoneIds,

--- a/src/IBI.WZDx/Models/RoadEvents/CdsCurbZonesReference.cs
+++ b/src/IBI.WZDx/Models/RoadEvents/CdsCurbZonesReference.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using IBI.WZDx.Equality;
+
+namespace IBI.WZDx.Models.RoadEvents;
+
+/// <summary>
+/// Describes specific curb zones that are impacted by a work zone via an external reference to the
+/// curb data specification's.
+/// </summary>
+/// <param name="CdsCurbZoneIds">A list of CDS Curb Zone Ids</param>
+/// <param name="CdsCurbsApiUrl">An identifier for the source of the requested CDS Curbs API.</param>
+public record CdsCurbZonesReference(
+    IEnumerable<string> CdsCurbZoneIds,
+    string CdsCurbsApiUrl
+    )
+{
+    /// <summary>
+    /// Determine if another <see cref="CdsCurbZonesReference"/> is equal to this <see cref="CdsCurbZonesReference"/>.
+    /// </summary>
+    public virtual bool Equals(CdsCurbZonesReference? other)
+    {
+        return other != null
+            && CdsCurbZoneIds.NullHandlingSequenceEqual(other.CdsCurbZoneIds)
+            && CdsCurbsApiUrl == other.CdsCurbsApiUrl;
+    }
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+
+        hash.Add(CdsCurbZoneIds);
+        hash.Add(CdsCurbsApiUrl);
+
+        return hash.ToHashCode();
+    }
+}

--- a/src/IBI.WZDx/Models/RoadEvents/CdsCurbZonesReference.cs
+++ b/src/IBI.WZDx/Models/RoadEvents/CdsCurbZonesReference.cs
@@ -30,7 +30,11 @@ public record CdsCurbZonesReference(
     {
         var hash = new HashCode();
 
-        hash.Add(CdsCurbZoneIds);
+        foreach (string id in CdsCurbZoneIds)
+        {
+            hash.Add(id);
+        }
+
         hash.Add(CdsCurbsApiUrl);
 
         return hash.ToHashCode();

--- a/src/IBI.WZDx/Models/RoadEvents/LaneStatus.cs
+++ b/src/IBI.WZDx/Models/RoadEvents/LaneStatus.cs
@@ -6,12 +6,12 @@ namespace IBI.WZDx.Models.RoadEvents;
 public enum LaneStatus
 {
     /// <summary>
-    /// The lane is open for travel.
+    /// The lane is open for normal usage.
     /// </summary>
     Open,
-    
+
     /// <summary>
-    /// The lane is closed to travel.
+    /// The lane is closed to normal usage.
     /// </summary>
     Closed,
 

--- a/src/IBI.WZDx/Models/RoadEvents/WorkZoneType.cs
+++ b/src/IBI.WZDx/Models/RoadEvents/WorkZoneType.cs
@@ -1,7 +1,9 @@
-﻿namespace IBI.WZDx.Models.RoadEvents;
+﻿using IBI.WZDx.Models.RoadEvents.WorkZones;
+
+namespace IBI.WZDx.Models.RoadEvents;
 
 /// <summary>
-/// The type of work zone road event.
+/// The type of <see cref="WorkZoneRoadEvent"/>.
 /// </summary>
 public enum WorkZoneType
 {

--- a/src/IBI.WZDx/Models/RoadEvents/WorkZoneType.cs
+++ b/src/IBI.WZDx/Models/RoadEvents/WorkZoneType.cs
@@ -19,7 +19,8 @@ public enum WorkZoneType
     Moving,
 
     /// <summary>
-    /// The planned extent of a moving operation. The active work area will be somewhere within this road event.
+    /// The road event is the planned extent of a moving operation. The active work area will be 
+    /// somewhere within this road event.
     /// </summary>
     /// <remarks>
     /// As opposed to <see cref="Moving"/>, the road event geometry typically does not actively change. 

--- a/src/IBI.WZDx/Models/RoadEvents/WorkZoneType.cs
+++ b/src/IBI.WZDx/Models/RoadEvents/WorkZoneType.cs
@@ -1,0 +1,28 @@
+﻿namespace IBI.WZDx.Models.RoadEvents;
+
+/// <summary>
+/// The type of work zone road event.
+/// </summary>
+public enum WorkZoneType
+{
+    /// <summary>
+    /// The road event is statically placed and is not moving.
+    /// </summary>
+    Static,
+
+    /// <summary>
+    /// The road event is actively moving on the roadway.
+    /// </summary>
+    /// <remarks>
+    /// As opposed to <see cref="PlannedMovingArea"/>, the road event geometry changes at the operation moves. 
+    /// </remarks>
+    Moving,
+
+    /// <summary>
+    /// The planned extent of a moving operation. The active work area will be somewhere within this road event.
+    /// </summary>
+    /// <remarks>
+    /// As opposed to <see cref="Moving"/>, the road event geometry typically does not actively change. 
+    /// </remarks>
+    PlannedMovingArea
+}

--- a/src/IBI.WZDx/Models/RoadEvents/WorkZones/WorkZoneRoadEvent.cs
+++ b/src/IBI.WZDx/Models/RoadEvents/WorkZones/WorkZoneRoadEvent.cs
@@ -152,7 +152,9 @@ public record WorkZoneRoadEvent(
             && TypesOfWork.NullHandlingSequenceEqual(other.TypesOfWork)
             && WorkerPresence == other.WorkerPresence
             && ReducedSpeedLimitKph == other.ReducedSpeedLimitKph
-            && Restrictions.NullHandlingSequenceEqual(other.Restrictions);
+            && Restrictions.NullHandlingSequenceEqual(other.Restrictions)
+            && ImpactedCdsCurbZones.NullHandlingSequenceEqual(other.ImpactedCdsCurbZones)
+            && WorkZoneType == other.WorkZoneType;
     }
 
     /// <inheritdoc/>
@@ -206,6 +208,16 @@ public record WorkZoneRoadEvent(
                 hash.Add(restriction);
             }
         }
+
+        if (ImpactedCdsCurbZones != null)
+        {
+            foreach(CdsCurbZonesReference cdsCurbZonesReference in ImpactedCdsCurbZones)
+            {
+                hash.Add(cdsCurbZonesReference);
+            }
+        }
+
+        hash.Add(WorkZoneType);
 
         return hash.ToHashCode();
     }

--- a/src/IBI.WZDx/Models/RoadEvents/WorkZones/WorkZoneRoadEvent.cs
+++ b/src/IBI.WZDx/Models/RoadEvents/WorkZones/WorkZoneRoadEvent.cs
@@ -97,7 +97,7 @@ namespace IBI.WZDx.Models.RoadEvents.WorkZones;
 /// impacted by the work zone.
 /// </param>
 /// <param name="WorkZoneType">
-/// The type of work zone road event, such as if the road event is staticor actively moving as part
+/// The type of work zone road event, such as if the road event is static or actively moving as part
 /// of a moving operation.
 /// </param>
 public record WorkZoneRoadEvent(

--- a/src/IBI.WZDx/Models/RoadEvents/WorkZones/WorkZoneRoadEvent.cs
+++ b/src/IBI.WZDx/Models/RoadEvents/WorkZones/WorkZoneRoadEvent.cs
@@ -89,8 +89,12 @@ namespace IBI.WZDx.Models.RoadEvents.WorkZones;
 /// A list of zero or more road restrictions that apply to the roadway segment described by this
 /// road event.
 /// </param>
-/// <param name="ImpactedCdsCurbZones">A list of references to external CDS Curb Zones impacted by 
-/// the work zone.</param>
+/// <param name="ImpactedCdsCurbZones">
+/// A list of references to external CDS Curb Zones impacted by the work zone.</param>
+/// <param name="WorkZoneType">
+/// The type of work zone road event, such as if the road event is staticor actively moving as part
+/// of a moving operation.
+/// </param>
 public record WorkZoneRoadEvent(
     RoadEventCoreDetails CoreDetails,
     DateTimeOffset StartDate,
@@ -116,7 +120,8 @@ public record WorkZoneRoadEvent(
     WorkerPresence? WorkerPresence = null,
     double? ReducedSpeedLimitKph = null,
     IEnumerable<Restriction>? Restrictions = null,
-    IEnumerable<CdsCurbZonesReference>? ImpactedCdsCurbZones = null
+    IEnumerable<CdsCurbZonesReference>? ImpactedCdsCurbZones = null,
+    WorkZoneType? WorkZoneType = null
     ) : IRoadEvent
 {
     /// <summary>

--- a/src/IBI.WZDx/Models/RoadEvents/WorkZones/WorkZoneRoadEvent.cs
+++ b/src/IBI.WZDx/Models/RoadEvents/WorkZones/WorkZoneRoadEvent.cs
@@ -89,6 +89,8 @@ namespace IBI.WZDx.Models.RoadEvents.WorkZones;
 /// A list of zero or more road restrictions that apply to the roadway segment described by this
 /// road event.
 /// </param>
+/// <param name="ImpactedCdsCurbZones">A list of references to external CDS Curb Zones impacted by 
+/// the work zone.</param>
 public record WorkZoneRoadEvent(
     RoadEventCoreDetails CoreDetails,
     DateTimeOffset StartDate,
@@ -113,7 +115,8 @@ public record WorkZoneRoadEvent(
     IEnumerable<TypeOfWork>? TypesOfWork = null,
     WorkerPresence? WorkerPresence = null,
     double? ReducedSpeedLimitKph = null,
-    IEnumerable<Restriction>? Restrictions = null
+    IEnumerable<Restriction>? Restrictions = null,
+    IEnumerable<CdsCurbZonesReference>? ImpactedCdsCurbZones = null
     ) : IRoadEvent
 {
     /// <summary>

--- a/src/IBI.WZDx/Models/RoadEvents/WorkZones/WorkZoneRoadEvent.cs
+++ b/src/IBI.WZDx/Models/RoadEvents/WorkZones/WorkZoneRoadEvent.cs
@@ -211,7 +211,7 @@ public record WorkZoneRoadEvent(
 
         if (ImpactedCdsCurbZones != null)
         {
-            foreach(CdsCurbZonesReference cdsCurbZonesReference in ImpactedCdsCurbZones)
+            foreach (CdsCurbZonesReference cdsCurbZonesReference in ImpactedCdsCurbZones)
             {
                 hash.Add(cdsCurbZonesReference);
             }

--- a/src/IBI.WZDx/Models/RoadEvents/WorkZones/WorkZoneRoadEvent.cs
+++ b/src/IBI.WZDx/Models/RoadEvents/WorkZones/WorkZoneRoadEvent.cs
@@ -90,7 +90,12 @@ namespace IBI.WZDx.Models.RoadEvents.WorkZones;
 /// road event.
 /// </param>
 /// <param name="ImpactedCdsCurbZones">
-/// A list of references to external CDS Curb Zones impacted by the work zone.</param>
+/// A list of references to external 
+/// <see href="https://github.com/openmobilityfoundation/curb-data-specification/tree/main/curbs#curb-zone">
+/// CDS Curb Zones
+/// </see> 
+/// impacted by the work zone.
+/// </param>
 /// <param name="WorkZoneType">
 /// The type of work zone road event, such as if the road event is staticor actively moving as part
 /// of a moving operation.

--- a/tests/IBI.WZDx.UnitTests/WzdxSerializerTests.cs
+++ b/tests/IBI.WZDx.UnitTests/WzdxSerializerTests.cs
@@ -122,7 +122,8 @@ public class WzdxSerializerTests
                                         Make: "Ver-Mac",
                                         Model: "AB-1",
                                         SerialNumber: "1234567890",
-                                        FirmwareVersion: "1.0.0"
+                                        FirmwareVersion: "1.0.0",
+                                        VelocityKph: 10.1
                                         ),
                                     Pattern: ArrowBoardPattern.RightArrowFlashing,
                                     IsMoving: false,
@@ -366,7 +367,8 @@ public class WzdxSerializerTests
                                         ""make"": ""Ver-Mac"",
                                         ""model"": ""AB-1"",
                                         ""serial_number"": ""1234567890"",
-                                        ""firmware_version"": ""1.0.0""
+                                        ""firmware_version"": ""1.0.0"",
+                                        ""velocity_kph"": 10.1
                                     },
                                     ""pattern"": ""right-arrow-flashing"",
                                     ""is_moving"": false,

--- a/tests/IBI.WZDx.UnitTests/WzdxSerializerTests.cs
+++ b/tests/IBI.WZDx.UnitTests/WzdxSerializerTests.cs
@@ -811,7 +811,8 @@ public class WzdxSerializerTests
                                             CdsCurbZoneIds: new string[] {"Zone Id 1", "Zone Id 2"},
                                             CdsCurbsApiUrl: "API Url"
                                             )
-                                    }
+                                    },
+                                    WorkZoneType: WorkZoneType.Static
                                     ),
                                 Geometry: new RoadEventFeatureGeometry(
                                     Type: RoadEventFeatureGeometryType.LineString,
@@ -975,7 +976,8 @@ public class WzdxSerializerTests
                                             ""cds_curb_zone_ids"": [ ""Zone Id 1"", ""Zone Id 2"" ],
                                             ""cds_curbs_api_url"": ""API Url""
                                         }
-                                    ]
+                                    ],
+                                    ""work_zone_type"": ""static""
                                 },
                                 ""geometry"": {
                                     ""type"": ""LineString"",

--- a/tests/IBI.WZDx.UnitTests/WzdxSerializerTests.cs
+++ b/tests/IBI.WZDx.UnitTests/WzdxSerializerTests.cs
@@ -804,6 +804,13 @@ public class WzdxSerializerTests
                                     Restrictions: new Restriction[]
                                     {
                                         new Restriction(RestrictionType.NoTrucks)
+                                    },
+                                    ImpactedCdsCurbZones: new CdsCurbZonesReference[]
+                                    {
+                                        new CdsCurbZonesReference(
+                                            CdsCurbZoneIds: new string[] {"Zone Id 1", "Zone Id 2"},
+                                            CdsCurbsApiUrl: "API Url"
+                                            )
                                     }
                                     ),
                                 Geometry: new RoadEventFeatureGeometry(
@@ -961,6 +968,12 @@ public class WzdxSerializerTests
                                     ""restrictions"": [
                                         {
                                             ""type"": ""no-trucks""
+                                        }
+                                    ],
+                                    ""impacted_cds_curb_zones"": [
+                                        {
+                                            ""cds_curb_zone_ids"": [ ""Zone Id 1"", ""Zone Id 2"" ],
+                                            ""cds_curbs_api_url"": ""API Url""
                                         }
                                     ]
                                 },


### PR DESCRIPTION
This PR adds the support for WZDx v4.2. The list of changes are as follows:

1) Add `CdsCurbZoneReference` record and `ImpactedCdsCurbZones` property to `WorkZoneRoadEvent`.
2) Add  `WorkZoneType` enum and `WorkZoneType` property to `WorkZoneRoadEvent`.
3) Add `InnerLoop` & `OuterLoop` to `RoadDirection` enum.
4) Add `WorkTruckWithLightsFlashing` to `MarkedLocationType` enum.
5) Update the summary comment for `Open` & `Closed` property in `LaneStatus` enum.
6) Update the summary comment for `FlashingBeacon`.
7) Add `VelocityKph` to `FieldDeviceCoreDetails`

See the [WZDx v4.2 Release Notes](https://github.com/usdot-jpo-ode/wzdx/releases/tag/v4.2) for the changes between v4.1 and v4.2.