### PR TITLE
Change WZDx Serializer to not include indentation/whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ DeviceFeed wzdxDeviceFeed = WzdxSerializer.DeserializeFeed<DeviceFeed>(wzdxDevic
 
 ## Versioning 
 
-The package uses [Semantic Versioning](https://semver.org/) in a MAJOR.MINOR.PATCH format.
+The package is versioned in a X.Y.Z format.
 
-The MAJOR and MINOR version numbers correspond to the MAJOR and MINOR version numbers of the [WZDx specification](https://github.com/usdot-jpo-ode/wzdx) that it conforms to.
+The X and Y version numbers correspond to the MAJOR and MINOR version numbers of the [WZDx specification](https://github.com/usdot-jpo-ode/wzdx) that it conforms to.
 
-The PATCH version number is incremented as changes are made to the library that are unrelated to progress of WZDx.
+The Z version number is incremented as changes are made to the library that are unrelated to progress of WZDx. It does not use Semantic Versioning. An increment of Z could be a breaking change.
 
 ## Tests
 
@@ -74,3 +74,4 @@ This solution includes a [IBI.WZDx.UnitTests](tests/IBI.WZDx.UnitTests) Xunit te
 ```
 dotnet test
 ```
+

--- a/src/IBI.WZDx/IBI.WZDx.csproj
+++ b/src/IBI.WZDx/IBI.WZDx.csproj
@@ -7,7 +7,7 @@
     <Description>Models and utitlies for producing and consuming Work Zone Data Exchange (WZDx) data feeds.</Description>
     <PackageTags>WZDx;Work Zone Data Exchange;Work Zone Feed;Road Event;Device Feed;Field Device;GeoJSON</PackageTags>
     <Authors>IBI Group</Authors>
-    <VersionPrefix>4.2.1</VersionPrefix>
+    <VersionPrefix>4.2.2</VersionPrefix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryType>git</RepositoryType>
@@ -26,3 +26,4 @@
   </ItemGroup>
 
 </Project>
+

--- a/src/IBI.WZDx/Serialization/WzdxSerializer.cs
+++ b/src/IBI.WZDx/Serialization/WzdxSerializer.cs
@@ -17,7 +17,6 @@ public static class WzdxSerializer
     {
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
         PropertyNamingPolicy = new SnakeCaseNamingPolicy(),
-        WriteIndented = true,
         Converters =
         {
             // System.Text.Json JsonStringEnumConverter does not use naming policy on


### PR DESCRIPTION
This PR modifies the WzdxSerializer JSON serialization options to not indent the JSON output, thus removing whitespace to reduce the size of the serialized feed.

It also updates the version number and version description in the README because this project is not using SemVer and this is actually a behavioral breaking change.